### PR TITLE
Enable returning metadata

### DIFF
--- a/inference_interface.py
+++ b/inference_interface.py
@@ -217,8 +217,9 @@ def numpy_to_toyfile(
                 ds.attrs[k] = dumps(md)
 
 
-def toyfiles_to_numpy(file_name_pattern, numpy_array_names=None,
-                      return_metadata=False):
+def toyfiles_to_numpy(
+        file_name_pattern, numpy_array_names=None,
+        return_metadata=False):
     filenames = sorted(glob(file_name_pattern))
     dtype_prototype = None
     results = {}

--- a/inference_interface.py
+++ b/inference_interface.py
@@ -226,7 +226,7 @@ def toyfiles_to_numpy(file_name_pattern, numpy_array_names=None,
     array_metadatas = {}
     for fn in filenames:
         with h5py.File(fn, "r") as f:
-            metadata[fn] = {k: v for k, v in f.attrs.items()}
+            metadata[fn] = {k: loads(v) for k, v in f.attrs.items()}
             array_metadatas[fn] = {}
             if numpy_array_names is None:
                 numpy_array_names = list(f["fits"].keys())
@@ -237,7 +237,7 @@ def toyfiles_to_numpy(file_name_pattern, numpy_array_names=None,
                     dtype_prototype = res.dtype
                 assert res.dtype == dtype_prototype
                 results[nan].append(res)
-                array_metadatas[fn][nan] = {k: v for k, v in f["fits/"+nan].attrs.items()}
+                array_metadatas[fn][nan] = {k: loads(v) for k, v in f["fits/"+nan].attrs.items()}
 
     for nan in numpy_array_names:
         results[nan] = np.concatenate(results[nan])

--- a/inference_interface.py
+++ b/inference_interface.py
@@ -217,12 +217,17 @@ def numpy_to_toyfile(
                 ds.attrs[k] = dumps(md)
 
 
-def toyfiles_to_numpy(file_name_pattern, numpy_array_names=None):
+def toyfiles_to_numpy(file_name_pattern, numpy_array_names=None,
+                      return_metadata=False):
     filenames = sorted(glob(file_name_pattern))
     dtype_prototype = None
     results = {}
+    metadata = {}
+    array_metadatas = {}
     for fn in filenames:
         with h5py.File(fn, "r") as f:
+            metadata[fn] = {k: v for k, v in f.attrs.items()}
+            array_metadatas[fn] = {}
             if numpy_array_names is None:
                 numpy_array_names = list(f["fits"].keys())
                 results = {rn:[] for rn in numpy_array_names}
@@ -232,9 +237,14 @@ def toyfiles_to_numpy(file_name_pattern, numpy_array_names=None):
                     dtype_prototype = res.dtype
                 assert res.dtype == dtype_prototype
                 results[nan].append(res)
+                array_metadatas[fn][nan] = {k: v for k, v in f["fits/"+nan].attrs.items()}
+
     for nan in numpy_array_names:
         results[nan] = np.concatenate(results[nan])
-    return results
+    if return_metadata:
+        return results, metadata, array_metadatas
+    else:
+        return results
 
 
 def dict_to_structured_array(d):


### PR DESCRIPTION
This adds the possibility to return metadata in `toyfiles_to_numpy`.
So far, the `metadata` and `array_metadatas` stored as attributes in the hdf5 file in `numpy_to_toyfile` have to be loaded manually, which can be a bit cumbersome.

Now you  can return them via
``` python
results, metadata, array_metadatas = toyfiles_to_numpy(file_name_pattern, return_metadata=True)

``` 

Both `metadata` and `array_metadatas` are dictionaries where the key is the filename and the value the respective metadata of the file.