### PR TITLE
Better metadata loading for toyfiles

### DIFF
--- a/inference_interface.py
+++ b/inference_interface.py
@@ -227,6 +227,12 @@ def toyfiles_to_numpy(
     A dictionary of numpy arrays is returned, indexed by the array names.
     If numpy_array_names is None, all arrays are loaded.
     If return_metadata is true, also the metadata is returned.
+
+    :param file_name_pattern: pattern of files to load
+    :param numpy_array_names: list of names of arrays to load.
+        If None, all are loaded.
+    :param return_metadata: if true, also the global metadata and
+        metadata for each array is returned.
     """
     filenames = sorted(glob(file_name_pattern))
     if len(filenames) == 0:

--- a/inference_interface.py
+++ b/inference_interface.py
@@ -221,6 +221,10 @@ def toyfiles_to_numpy(
         file_name_pattern, numpy_array_names=None,
         return_metadata=False):
     filenames = sorted(glob(file_name_pattern))
+    if len(filenames) == 0:
+        message = "No files found with pattern {:s}".format(file_name_pattern)
+        raise FileNotFoundError(message)
+
     dtype_prototype = None
     results = {}
     metadata = {}

--- a/inference_interface.py
+++ b/inference_interface.py
@@ -266,8 +266,15 @@ def toyfiles_to_numpy(
     for nan in numpy_array_names:
         results[nan] = np.concatenate(results[nan])
     if return_metadata:
+        dtype_prototype = results["metadata"][0].dtype
+        for md in results["metadata"]:
+            assert md.dtype == dtype_prototype
         results["metadata"] = np.concatenate(results["metadata"])
+
         for nan in numpy_array_names:
+            dtype_prototype = results[f"metadata_{nan}"][0].dtype
+            for md in results[f"metadata_{nan}"]:
+                assert md.dtype == dtype_prototype
             results[f"metadata_{nan}"] = np.concatenate(results[f"metadata_{nan}"])
 
     return results

--- a/inference_interface.py
+++ b/inference_interface.py
@@ -255,7 +255,8 @@ def toyfiles_to_numpy(
                 if return_metadata:
                     metadata = {k: loads(v) for k, v in f["fits/"+nan].attrs.items()}
                     metadata_arr = metadata_to_structured_array(metadata)
-                    results[f"metadata_{nan}"].append(np.repeat(metadata_arr, len(res)))
+                    new_entry = np.repeat(metadata_arr, len(res))
+                    results[f"metadata_{nan}"].append(new_entry)
             if return_metadata:
                 metadata = {k: loads(v) for k, v in f.attrs.items()}
                 metadata_arr = metadata_to_structured_array(metadata)
@@ -306,9 +307,9 @@ def metadata_to_structured_array(metadata: dict):
         return np.array([], dtype=[("empty", float)])
     # unpack nested dicts into top level and name them accordingly
     metadata_unpacked = deepcopy(metadata)
-    for k, v in metadata.items():
+    for k, v in sorted(metadata.items()):
         if isinstance(v, dict):
-            for k2, v2 in v.items():
+            for k2, v2 in sorted(v.items()):
                 metadata_unpacked[f"{k}_{k2}"] = v2
             del metadata_unpacked[k]
     df = pd.DataFrame([metadata_unpacked])


### PR DESCRIPTION
This pull request changes how metadata is loaded so that it's more usefull. Instead of just returning a dict for each file, we now add an entry `"metadata"` (plus an entry for each of the `array_metadatas`) to the returned results dict that is a structured array and has the same dimensions as the results.

This way you can easily relate information from the metadata to each toy experiment.

In addition, I added a short docstring and raise an fnf error in case the patterns don't match any file.